### PR TITLE
Add GitHub Actions job to automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           git tag -d ${{ github.event.inputs.version_number }}
           git remote update
           git checkout tags/${{ github.event.inputs.version_number }}
-          git diff origin/${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
   create-zip:
     needs: tag-commit
     name: Create ZIP and verify package for release asset.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit ID to tag and create a release for'
+        required: true
+      version_number:
+        description: 'Release Version Number (Eg, v1.0.0)'
+        required: true
+
+jobs:
+  tag-commit:
+    name: Tag commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+      - name: Configure git identity
+        run: |
+            git config --global user.name "Release Workflow"
+      - name: Tag Commit and Push to remote
+        run: |
+          git tag ${{ github.event.inputs.version_number }} -a -m "coreMQTT Library ${{ github.event.inputs.version_number }}"
+          git push origin --tags
+      - name: Verify tag on remote
+        run: |
+          git tag -d ${{ github.event.inputs.version_number }}
+          git remote update
+          git checkout tags/${{ github.event.inputs.version_number }}
+          git diff origin/${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+  create-zip:
+    needs: tag-commit
+    name: Create ZIP and verify package for release asset.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install ZIP tools
+        run: sudo apt-get install zip unzip
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+          path: coreMQTT
+          submodules: recursive
+      - name: Checkout disabled submodules
+        run: |
+          cd coreMQTT
+          git submodule update --init --checkout --recursive
+      - name: Create ZIP
+        run: |
+          zip -r coreMQTT-${{ github.event.inputs.version_number }}.zip coreMQTT -x "*.git*"
+          ls ./
+      - name: Validate created ZIP
+        run: |
+          mkdir zip-check
+          mv coreMQTT-${{ github.event.inputs.version_number }}.zip zip-check
+          cd zip-check
+          unzip coreMQTT-${{ github.event.inputs.version_number }}.zip -d coreMQTT-${{ github.event.inputs.version_number }}
+          ls coreMQTT-${{ github.event.inputs.version_number }}
+          diff -r -x "*.git*" coreMQTT-${{ github.event.inputs.version_number }}/coreMQTT/ ../coreMQTT/
+          cd ../
+      - name: Build
+        run: |
+          cd zip-check/coreMQTT-${{ github.event.inputs.version_number }}/coreMQTT
+          sudo apt-get install -y lcov
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          make -C build/ all
+      - name: Test
+        run: |
+          cd zip-check/coreMQTT-${{ github.event.inputs.version_number }}/coreMQTT/build/
+          ctest -E system --output-on-failure
+          cd ..
+      - name: Create artifact of ZIP
+        uses: actions/upload-artifact@v2
+        with:
+          name: coreMQTT-${{ github.event.inputs.version_number }}.zip
+          path: zip-check/coreMQTT-${{ github.event.inputs.version_number }}.zip
+  create-release:
+    needs: create-zip
+    name: Create Release and Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version_number }}
+          release_name: ${{ github.event.inputs.version_number }}
+          body: Release ${{ github.event.inputs.version_number }} of the coreMQTT Library.
+          draft: false
+          prerelease: false
+      - name: Download ZIP artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: coreMQTT-${{ github.event.inputs.version_number }}.zip
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./coreMQTT-${{ github.event.inputs.version_number }}.zip
+          asset_name: coreMQTT-${{ github.event.inputs.version_number }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             git config --global user.name "Release Workflow"
       - name: Tag Commit and Push to remote
         run: |
-          git tag ${{ github.event.inputs.version_number }} -a -m "coreMQTT Library ${{ github.event.inputs.version_number }}"
+          git tag ${{ github.event.inputs.version_number }} -a -m "backoffAlgorithm Library ${{ github.event.inputs.version_number }}"
           git push origin --tags
       - name: Verify tag on remote
         run: |
@@ -43,45 +43,45 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.commit_id }}
-          path: coreMQTT
+          path: backoffAlgorithm
           submodules: recursive
       - name: Checkout disabled submodules
         run: |
-          cd coreMQTT
+          cd backoffAlgorithm
           git submodule update --init --checkout --recursive
       - name: Create ZIP
         run: |
-          zip -r coreMQTT-${{ github.event.inputs.version_number }}.zip coreMQTT -x "*.git*"
+          zip -r backoffAlgorithm-${{ github.event.inputs.version_number }}.zip backoffAlgorithm -x "*.git*"
           ls ./
       - name: Validate created ZIP
         run: |
           mkdir zip-check
-          mv coreMQTT-${{ github.event.inputs.version_number }}.zip zip-check
+          mv backoffAlgorithm-${{ github.event.inputs.version_number }}.zip zip-check
           cd zip-check
-          unzip coreMQTT-${{ github.event.inputs.version_number }}.zip -d coreMQTT-${{ github.event.inputs.version_number }}
-          ls coreMQTT-${{ github.event.inputs.version_number }}
-          diff -r -x "*.git*" coreMQTT-${{ github.event.inputs.version_number }}/coreMQTT/ ../coreMQTT/
+          unzip backoffAlgorithm-${{ github.event.inputs.version_number }}.zip -d backoffAlgorithm-${{ github.event.inputs.version_number }}
+          ls backoffAlgorithm-${{ github.event.inputs.version_number }}
+          diff -r -x "*.git*" backoffAlgorithm-${{ github.event.inputs.version_number }}/backoffAlgorithm/ ../backoffAlgorithm/
           cd ../
       - name: Build
         run: |
-          cd zip-check/coreMQTT-${{ github.event.inputs.version_number }}/coreMQTT
+          cd zip-check/backoffAlgorithm-${{ github.event.inputs.version_number }}/backoffAlgorithm
           sudo apt-get install -y lcov
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror'
           make -C build/ all
       - name: Test
         run: |
-          cd zip-check/coreMQTT-${{ github.event.inputs.version_number }}/coreMQTT/build/
+          cd zip-check/backoffAlgorithm-${{ github.event.inputs.version_number }}/backoffAlgorithm/build/
           ctest -E system --output-on-failure
           cd ..
       - name: Create artifact of ZIP
         uses: actions/upload-artifact@v2
         with:
-          name: coreMQTT-${{ github.event.inputs.version_number }}.zip
-          path: zip-check/coreMQTT-${{ github.event.inputs.version_number }}.zip
+          name: backoffAlgorithm-${{ github.event.inputs.version_number }}.zip
+          path: zip-check/backoffAlgorithm-${{ github.event.inputs.version_number }}.zip
   create-release:
     needs: create-zip
     name: Create Release and Upload Release Asset
@@ -95,13 +95,13 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.version_number }}
           release_name: ${{ github.event.inputs.version_number }}
-          body: Release ${{ github.event.inputs.version_number }} of the coreMQTT Library.
+          body: Release ${{ github.event.inputs.version_number }} of the backoffAlgorithm Library.
           draft: false
           prerelease: false
       - name: Download ZIP artifact
         uses: actions/download-artifact@v2
         with:
-          name: coreMQTT-${{ github.event.inputs.version_number }}.zip
+          name: backoffAlgorithm-${{ github.event.inputs.version_number }}.zip
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -109,6 +109,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./coreMQTT-${{ github.event.inputs.version_number }}.zip
-          asset_name: coreMQTT-${{ github.event.inputs.version_number }}.zip
+          asset_path: ./backoffAlgorithm-${{ github.event.inputs.version_number }}.zip
+          asset_name: backoffAlgorithm-${{ github.event.inputs.version_number }}.zip
           asset_content_type: application/zip


### PR DESCRIPTION
**Add a GitHub Action job to trigger a release process** which includes operations of: 
1. Creating and pushing the release tag to the repository 
2. Verifying the pushed tag (performing a diff with the commit ID which is tagged) 
3. Creating a ZIP for the release asset. 
4. Verifying the ZIP by performing a diff check and running unit tests on the unzipped files. 5. Creating a release on the repository for the tag, and uploading the ZIP as the release asset

The workflow can be manually triggered and takes the input values of **Commit ID** (to create a release for) and the **Version string** for tagging the release with

**Testing**
Here is an example run of the release job on my fork repository: 
https://github.com/aggarw13/backoffAlgorithm/actions/runs/406488189
It pushed the test tag (`test-v2`) and created a release along with the release asset on the repository: https://github.com/aggarw13/backoffAlgorithm/releases/tag/test-v3