### PR TITLE
Add stdint.readme for C90 compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,17 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
+  custom-standard-c-header:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          mkdir -p override-include
+          cp source/include/stdint.readme override-include/stdint.h
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -I../override-include'
+          make -C build/ coverity_analysis          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,4 +158,4 @@ jobs:
           -G "Unix Makefiles" \
           -DBUILD_CLONE_SUBMODULES=ON \
           -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -I../override-include'
-          make -C build/ coverity_analysis          
+          make -C build/ coverity_analysis

--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ int main()
 
 ## Building the library
 
-A compiler that supports **C89 or later** such as *gcc* is required to build the library.
+A compiler that supports **C90 or later** such as *gcc* is required to build the library.
+
+Additionally, the library uses a header file introduced in ISO C99, `stdint.h`. For compilers that do not provide this header file, the [source/include](source/include) directory contains [stdint.readme](source/include/stdint.readme), which can be renamed to `stdint.h` to
+build the backoffAlgorithm library.
 
 For instance, if the example above is copied to a file named `example.c`, *gcc* can be used like so:
 ```bash

--- a/source/backoff_algorithm.c
+++ b/source/backoff_algorithm.c
@@ -27,7 +27,6 @@
  */
 
 /* Standard includes. */
-#include <stdlib.h>
 #include <assert.h>
 
 /* Include API header. */

--- a/source/backoff_algorithm.c
+++ b/source/backoff_algorithm.c
@@ -28,6 +28,7 @@
 
 /* Standard includes. */
 #include <assert.h>
+#include <stddef.h>
 
 /* Include API header. */
 #include "backoff_algorithm.h"

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -26,7 +26,7 @@ typedef long long            int64_t;
 typedef unsigned long long   uint64_t;
 
 #define INT8_MAX      ( ( signed char ) 127 )
-#define UINT8_MAX     ( ( unsigned char ) ) 255
+#define UINT8_MAX     ( ( unsigned char ) 255 )
 #define INT16_MAX     ( ( short ) 32767 )
 #define UINT16_MAX    ( ( unsigned short ) 65535 )
 #define INT32_MAX     2147483647L

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -1,0 +1,37 @@
+#ifndef _STDINT_H
+#define _STDINT_H
+
+/*******************************************************************************
+ * THIS IS NOT A FULL stdint.h IMPLEMENTATION - It only contains the definitions
+ * necessary to build the coreMQTT code.  It is provided to allow coreMQTT to be
+ * built using compilers that do not provide their own stdint.h definition.
+ *
+ * To use this file:
+ *
+ *    1) Copy this file into a directory that is in your compiler's include path.
+ *       The directory must be part of the include path for system header file,
+ *       for example passed using gcc's "-I" or "-isystem" options.
+ *
+ *    2) Rename the copied file stdint.h.
+ *
+ */
+
+typedef signed char          int8_t;
+typedef unsigned char        uint8_t;
+typedef short                int16_t;
+typedef unsigned short       uint16_t;
+typedef long                 int32_t;
+typedef unsigned long        uint32_t;
+typedef long long            int64_t;
+typedef unsigned long long   uint64_t;
+
+#define INT8_MAX      ( ( signed char ) 127 )
+#define UINT8_MAX     ( ( unsigned char ) ) 255
+#define INT16_MAX     ( ( short ) 32767 )
+#define UINT16_MAX    ( ( unsigned short ) 65535 )
+#define INT32_MAX     2147483647L
+#define UINT32_MAX    4294967295UL
+#define INT64_MAX     9223372036854775807LL
+#define UINT64_MAX    18446744073709551615ULL
+
+#endif /* _STDINT_H */

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -3,8 +3,8 @@
 
 /*******************************************************************************
  * THIS IS NOT A FULL stdint.h IMPLEMENTATION - It only contains the definitions
- * necessary to build the coreMQTT code.  It is provided to allow coreMQTT to be
- * built using compilers that do not provide their own stdint.h definition.
+ * necessary to build the library code.  It is provided to allow the library to
+ * be built using compilers that do not provide their own stdint.h definition.
  *
  * To use this file:
  *


### PR DESCRIPTION
Add a `stdint.readme` file to support toolchains that do not provide the `stdint.h` file for integer `typedefs`. With the provision of this file, the library can be used against C90 compilers. This PR also adds a CI check to ensure successful library builds when using the `stdint.readme` file for the standard C library header.