### PR TITLE
Fix MISRA violations of 10.4 and 10.7 rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- [#24](https://github.com/FreeRTOS/backoffAlgorithm/pull/24) Fix MISRA 10.4 and 10.7 rule violations, and add documentation of MISRA compliance.
 - [#18](https://github.com/FreeRTOS/backoffAlgorithm/pull/18), [#19](https://github.com/FreeRTOS/backoffAlgorithm/pull/19), and [#20](https://github.com/FreeRTOS/backoffAlgorithm/pull/20) Documentation fixes.
 
 ## v1.0.0 (December 2020)

--- a/MISRA.md
+++ b/MISRA.md
@@ -1,0 +1,18 @@
+# MISRA Compliance
+
+The backoffAlgorithm library files conform to the [MISRA C:2012](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx)
+guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
+Deviations from the MISRA standard are listed below:
+
+### Ignored by [Coverity Configuration](tools/coverity/misra.config)
+| Deviation | Category | Justification |
+| :-: | :-: | :-: |
+| Directive 4.9 | Advisory | Allow inclusion of function like macros. |
+| Rule 3.1 | Required | Allow nested comments. C++ style `//` comments are used in example code within Doxygen documentation blocks. |
+| Rule 2.4 | Advisory | Allow unused tags. Some compilers warn if types are not tagged. |
+
+### Flagged by Coverity
+| Deviation | Category | Justification |
+| :-: | :-: | :-: |
+| Rule 8.7 | Advisory | API functions are not used by the library; however, they must be externally visible in order to be used by an application. |
+

--- a/source/backoff_algorithm.c
+++ b/source/backoff_algorithm.c
@@ -52,7 +52,7 @@ BackoffAlgorithmStatus_t BackoffAlgorithm_GetNextBackoff( BackoffAlgorithmContex
          * for the retry attempt. */
 
         /* Choose a random value for back-off time between 0 and the max jitter value. */
-        *pNextBackOff = ( uint16_t ) ( randomValue % ( pRetryContext->nextJitterMax + 1UL ) );
+        *pNextBackOff = ( uint16_t ) ( randomValue % ( pRetryContext->nextJitterMax + ( uint32_t ) 1U ) );
 
         /* Increment the retry attempt. */
         pRetryContext->attemptsDone++;

--- a/source/backoff_algorithm.c
+++ b/source/backoff_algorithm.c
@@ -52,7 +52,7 @@ BackoffAlgorithmStatus_t BackoffAlgorithm_GetNextBackoff( BackoffAlgorithmContex
          * for the retry attempt. */
 
         /* Choose a random value for back-off time between 0 and the max jitter value. */
-        *pNextBackOff = ( uint16_t ) ( randomValue % ( pRetryContext->nextJitterMax + 1U ) );
+        *pNextBackOff = ( uint16_t ) ( randomValue % ( pRetryContext->nextJitterMax + 1UL ) );
 
         /* Increment the retry attempt. */
         pRetryContext->attemptsDone++;

--- a/source/include/backoff_algorithm.h
+++ b/source/include/backoff_algorithm.h
@@ -40,7 +40,7 @@
  * @ingroup backoff_algorithm_constants
  * @brief Constant to represent unlimited number of retry attempts.
  */
-#define BACKOFF_ALGORITHM_RETRY_FOREVER    0
+#define BACKOFF_ALGORITHM_RETRY_FOREVER    ( 0U )
 
 /**
  * @ingroup backoff_algorithm_enum_types

--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -1,0 +1,22 @@
+// MISRA C-2012 Rules
+
+{
+    version : "2.0",
+    standard : "c2012",
+    title: "Coverity MISRA Configuration",
+    deviations : [
+        // Disable the following rules.
+        {
+            deviation: "Directive 4.9",
+            reason: "Allow inclusion of function like macros. Logging is done using function like macros."
+        },
+        {
+            deviation: "Rule 2.4",
+            reason: "Allow unused tags. Some compilers warn if types are not tagged."
+        },
+        {
+            deviation: "Rule 3.1",
+            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+        }
+    ]
+}


### PR DESCRIPTION
Fix MISRA violations of Rule **10.4** and Rule **10.7**. Also, add library-specific **misra.config** (to ignore some MISRA rules) and **MISRA.m** (for public documentation of MISRA compliance) files.