### PR TITLE
Fix comment in BackoffAlgorithm_GetNextBackoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for backoffAlgorithm Library
 
+## Changes after v1.0.1
+- [#27](https://github.com/FreeRTOS/backoffAlgorithm/pull/26) Fix incorrect comment about use of BACKOFF_ALGORITHM_RETRY_FOREVER constant in BackoffAlgorithm_GetNextBackoff API.
+
 ## v1.0.1 (February 2020)
 
 ### Changes

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -31,7 +31,7 @@ longjmp
 mainpage
 maxattempts
 maxbackoff
-maxretryattmpts
+maxretryattempts
 min
 misra
 mockrng

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -31,6 +31,7 @@ longjmp
 mainpage
 maxattempts
 maxbackoff
+maxretryattmpts
 min
 misra
 mockrng

--- a/source/backoff_algorithm.c
+++ b/source/backoff_algorithm.c
@@ -44,7 +44,7 @@ BackoffAlgorithmStatus_t BackoffAlgorithm_GetNextBackoff( BackoffAlgorithmContex
     assert( pRetryContext != NULL );
     assert( pNextBackOff != NULL );
 
-    /* If BACKOFF_ALGORITHM_RETRY_FOREVER is set to 0, try forever. */
+    /* If maxRetryAttmpts state of the context is set to 0, retry forever. */
     if( ( pRetryContext->attemptsDone < pRetryContext->maxRetryAttempts ) ||
         ( pRetryContext->maxRetryAttempts == BACKOFF_ALGORITHM_RETRY_FOREVER ) )
     {

--- a/source/backoff_algorithm.c
+++ b/source/backoff_algorithm.c
@@ -44,7 +44,7 @@ BackoffAlgorithmStatus_t BackoffAlgorithm_GetNextBackoff( BackoffAlgorithmContex
     assert( pRetryContext != NULL );
     assert( pNextBackOff != NULL );
 
-    /* If maxRetryAttmpts state of the context is set to 0, retry forever. */
+    /* If maxRetryAttempts state of the context is set to 0, retry forever. */
     if( ( pRetryContext->attemptsDone < pRetryContext->maxRetryAttempts ) ||
         ( pRetryContext->maxRetryAttempts == BACKOFF_ALGORITHM_RETRY_FOREVER ) )
     {


### PR DESCRIPTION
Fix invalid comment about meaning of **BACKOFF_ALGORITHM_RETRY_FOREVER** constant in `BackoffAlgorithm_GetNextBackoff`API. The issue was pointed in #26.