### PR TITLE
Update broken MISRA link

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -1,6 +1,6 @@
 # MISRA Compliance
 
-The backoffAlgorithm library files conform to the [MISRA C:2012](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx)
+The backoffAlgorithm library files conform to the [MISRA C:2012](https://www.misra.org.uk)
 guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
 Deviations from the MISRA standard are listed below:
 


### PR DESCRIPTION
Because the MISRA website was updated, an older link is no longer valid. Update the link so that it just points to the domain to avoid this from happening again.